### PR TITLE
Fix the bug where getTimes return incorrect day

### DIFF
--- a/lib/src/date_utils.dart
+++ b/lib/src/date_utils.dart
@@ -6,7 +6,7 @@ num toJulian(DateTime date) {
 
 DateTime fromJulian(num j) {
   return DateTime.fromMillisecondsSinceEpoch(
-      ((j + 0.5 - 1970) * dayMs).round());
+      ((j + 0.5 - j1970) * dayMs).round());
 }
 
 num toDays(DateTime date) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dev_dependencies:
   flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
+  test: ^1.25.15
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/apsl_sun_calc_test.dart
+++ b/test/apsl_sun_calc_test.dart
@@ -1,1 +1,63 @@
-void main() {}
+import 'package:test/test.dart';
+import 'package:apsl_sun_calc/apsl_sun_calc.dart';
+
+void main() {
+  group('SunCalc', () {
+    test('getSunPosition returns correct keys', () {
+      final pos =
+          SunCalc.getSunPosition(DateTime.utc(2025, 7, 1, 12), 43.0, -79.0);
+      expect(pos.containsKey('azimuth'), isTrue);
+      expect(pos.containsKey('altitude'), isTrue);
+    });
+
+    test('getTimes returns solarNoon and nadir', () async {
+      final times =
+          await SunCalc.getTimes(DateTime(2025, 7, 1, 12), 43.0, -79.0);
+      expect(times.containsKey('sunrise'), isTrue);
+      expect(times['sunrise']?.year, 2025);
+      expect(times['sunrise']?.month, 7);
+      expect(times['sunrise']?.day, 1);
+      expect(times.containsKey('solarNoon'), isTrue);
+      expect(times.containsKey('nadir'), isTrue);
+    });
+
+    test('getMoonPosition returns correct keys', () {
+      final pos =
+          SunCalc.getMoonPosition(DateTime.utc(2025, 7, 1, 12), 43.0, -79.0);
+      expect(pos.containsKey('azimuth'), isTrue);
+      expect(pos.containsKey('altitude'), isTrue);
+      expect(pos.containsKey('distance'), isTrue);
+      expect(pos.containsKey('parallacticAngle'), isTrue);
+    });
+
+    test('getMoonIllumination returns correct keys', () {
+      final illum = SunCalc.getMoonIllumination(DateTime.utc(2025, 7, 1));
+      expect(illum.containsKey('fraction'), isTrue);
+      expect(illum.containsKey('phase'), isTrue);
+      expect(illum.containsKey('angle'), isTrue);
+    });
+
+    test('getMoonTimes returns rise or set or alwaysUp/alwaysDown', () {
+      final moonTimes =
+          SunCalc.getMoonTimes(DateTime.utc(2025, 7, 1), 43.0, -79.0);
+      expect(
+        moonTimes.containsKey('rise') ||
+            moonTimes.containsKey('set') ||
+            moonTimes['alwaysUp'] == true ||
+            moonTimes['alwaysDown'] == true,
+        isTrue,
+      );
+      expect(moonTimes['rise']?.year, 2025);
+      expect(moonTimes['rise']?.month, 7);
+      expect(moonTimes['rise']?.day, 1);
+    });
+
+    test('addTime adds a new time to times list', () {
+      final initialLength = times.length;
+      SunCalc.addTime(-4, 'customRise', 'customSet');
+      expect(times.length, initialLength + 1);
+      expect(times.last[1], 'customRise');
+      expect(times.last[2], 'customSet');
+    });
+  });
+}


### PR DESCRIPTION
Fix: getTimes used to return correct time in the day but incorrect day.
Feat: Add simple test cases to the library